### PR TITLE
v0.6.28 public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.28] - Unreleased
+## [0.6.28] - 2025-05-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.28] - Unreleased
+
+### Added
+
+- Add Esxi/HyperV StandAlone Host to the Backup Infrastructure diagram
+
+### Changed
+
+- Bump module version to v0.6.28
+
+### Fixed
+
+- Fix [#65](https://github.com/rebelinux/Veeam.Diagrammer/issues/65)
+- Resolve [#217](https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR/issues/217)
+
 ## [0.6.27] - 2025-05-10
 
 ### Changed

--- a/Src/Private/Get-DiagBackupToViProxy.ps1
+++ b/Src/Private/Get-DiagBackupToViProxy.ps1
@@ -5,7 +5,7 @@ function Get-DiagBackupToViProxy {
     .DESCRIPTION
         Build a diagram of the configuration of Veeam VBR in PDF/PNG/SVG formats using Psgraph.
     .NOTES
-        Version:        0.6.22
+        Version:        0.6.28
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -94,7 +94,7 @@ function Get-DiagBackupToViProxy {
                 if ($vSphereServerObj = Get-VbrBackupvSphereStandAloneInfo | Sort-Object) {
 
                     $columnSize = & {
-                        if (($SphereServerObj | Measure-Object).count -le 1 ) {
+                        if (($vSphereServerObj | Measure-Object).count -le 1 ) {
                             return 1
                         } else {
                             return 4

--- a/Veeam.Diagrammer.psd1
+++ b/Veeam.Diagrammer.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Veeam.Diagrammer.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.6.27'
+    ModuleVersion = '0.6.28'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
## [0.6.28] - 2025-05-14

### Added

- Add Esxi/HyperV StandAlone Host to the Backup Infrastructure diagram

### Changed

- Bump module version to v0.6.28

### Fixed

- Fix [#65](https://github.com/rebelinux/Veeam.Diagrammer/issues/65)
- Resolve [#217](https://github.com/AsBuiltReport/AsBuiltReport.Veeam.VBR/issues/217)